### PR TITLE
Better game ordering

### DIFF
--- a/app/assets/stylesheets/global.css.scss
+++ b/app/assets/stylesheets/global.css.scss
@@ -276,6 +276,10 @@ ul.games {
   }
 }
 
+#order_by_top {
+  margin-top: 18px;
+}
+
 img.boxart {
   width: 100%;
   margin-bottom: 10px;

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -24,14 +24,16 @@ class GamesController < ApplicationController
 
     # Order
     case params[:order_by]
-    when "title"
-      @games = @games.reorder("title ASC")
     when "updated_at"
       @games = @games.reorder("updated_at DESC")
+    when "reviews_count"
+      @games = @games.reorder("approved_reviews_count DESC")
     when "created_at"
       @games = @games.reorder("created_at DESC")
+    when "title"
+      @games = @games.reorder("title ASC")
     else
-      params.delete :order_by
+      @games = @games.reorder("updated_at DESC")
     end
 
     # Paginate

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -27,7 +27,7 @@ class GamesController < ApplicationController
     when "updated_at"
       @games = @games.reorder("updated_at DESC")
     when "reviews_count"
-      @games = @games.reorder("approved_reviews_count DESC")
+      @games = @games.reorder("approved_reviews_count DESC, updated_at DESC")
     when "created_at"
       @games = @games.reorder("created_at DESC")
     when "title"

--- a/app/controllers/player_reviews_controller.rb
+++ b/app/controllers/player_reviews_controller.rb
@@ -40,7 +40,6 @@ class PlayerReviewsController < ApplicationController
   def update
     if @player_review.update_attributes(params[:player_review])
       if current_user.is_admin?
-        @player_review.approve!
         flash[:success] = "Player review updated. #{undo_link}".html_safe
       else
         @player_review.make_pending!

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -5,7 +5,7 @@ class Game < ActiveRecord::Base
   								:cost_list, :intended_for_list, :developer_type_list,
                                 :teacher_info, :entertainment
 
-  default_scope order: 'title ASC'
+  default_scope order: 'games.updated_at DESC, games.title ASC'
   scope :enabled, where(disabled: false)
   scope :disabled, where(disabled: true)
 

--- a/app/models/player_review.rb
+++ b/app/models/player_review.rb
@@ -10,6 +10,8 @@ class PlayerReview < ActiveRecord::Base
 
   has_paper_trail
 
+  after_save :touch_game_if_approved
+
   validates :title,		presence: true
   validates :content, presence: true
 
@@ -46,6 +48,13 @@ class PlayerReview < ActiveRecord::Base
 
   def make_pending!
   	self.update_attribute(:status, 'Pending')
+  end
+
+  def touch_game_if_approved
+    # so that the game will jump to the top of any "most recently updated" lists
+    if status == 'Approved'
+      game.touch
+    end
   end
 
   def ratings_total

--- a/app/models/player_review.rb
+++ b/app/models/player_review.rb
@@ -4,6 +4,8 @@ class PlayerReview < ActiveRecord::Base
 
   default_scope order: 'created_at DESC'
 
+  scope :approved, -> { where(status: "Approved") }
+
   belongs_to :game
   belongs_to :user
   has_many :comments, as: :commentable

--- a/app/models/player_review.rb
+++ b/app/models/player_review.rb
@@ -13,6 +13,7 @@ class PlayerReview < ActiveRecord::Base
   has_paper_trail
 
   after_save :touch_game_if_approved
+  after_save :update_game_approved_reviews_count
 
   validates :title,		presence: true
   validates :content, presence: true
@@ -56,6 +57,12 @@ class PlayerReview < ActiveRecord::Base
     # so that the game will jump to the top of any "most recently updated" lists
     if status == 'Approved'
       game.touch
+    end
+  end
+
+  def update_game_approved_reviews_count
+    unless game.approved_reviews_count == game.player_reviews.approved.count
+      game.update_column(:approved_reviews_count, game.player_reviews.approved.count)
     end
   end
 

--- a/app/views/games/_categories_bar.html.erb
+++ b/app/views/games/_categories_bar.html.erb
@@ -1,12 +1,13 @@
+<% order_array = [["order_by", "Order by"]] %>
 <% categories_array = [["subject", "Subjects"], ["platform", "Platforms"], ["cost", "Costs"], ["intended_for", "Intended Ages"], ["developer_type","Developer Types"]] %>
 
 <%= form_tag(url_for(params), method: "get") do %>
   <%= search_field_tag(:title, params[:title], placeholder: "Search by title", class: 'span2') %>
-  <% categories_array.each do |s, f| %>
+  
+  <% (order_array+categories_array).each do |s, f| %>
   <%= hidden_field_tag(s, params[s]) if params[s].present? %>
   <% end %>
 <% end %>
-
 
 <h2 id="categories_top">Categories</h2>
 
@@ -16,11 +17,15 @@
 </div>
 <% end %>
 
+<h2 id="order_by_top">Order by</h2>
+<div id="orber_by_dropdown">
+<%= select :game, "order_by", [["Most recently reviewed or updated first", "updated_at"], ["Newest first", "created_at"], ["Title A-Z", "title"]], selected: "updated_at" %>
+</div>
 
 
 <script>
 $(document).ready(function() {
-<% categories_array.each do |s, f| %>
+<% (order_array+categories_array).each do |s, f| %>
 
   <% if params[s] %>
   	$('#game_<%=s%>').val("<%= params[s] %>");

--- a/app/views/games/_categories_bar.html.erb
+++ b/app/views/games/_categories_bar.html.erb
@@ -19,7 +19,7 @@
 
 <h2 id="order_by_top">Order by</h2>
 <div id="orber_by_dropdown">
-<%= select :game, "order_by", [["Most recently reviewed or updated first", "updated_at"], ["Newest first", "created_at"], ["Title A-Z", "title"]], selected: "updated_at" %>
+<%= select :game, "order_by", [["Last reviewed or updated", "updated_at"], ["Most reviews", "reviews_count"], ["Last added", "created_at"], ["Title A-Z", "title"]] %>
 </div>
 
 

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -17,7 +17,7 @@
 					<% end %>
 			  <%= render 'games/game_info', game: game, hide_title: true %>
 			  <%= tracked_link_to "Play on this game's site!", game.website_url, class: "btn btn-success", style: "margin: 5px; font-weight: bold;", target: "_blank" %>
-				<%= link_to 'See Scorecards', "#{game_path(game)}#scorecards", class: "btn btn-info", style: "margin: 5px; font-weight: bold;" %>
+				<%= link_to "Read #{game.player_reviews.approved.count > 0 ? pluralize(game.player_reviews.approved.count, 'Review') : "Reviews"}", "#{game_path(game)}#scorecards", class: "btn btn-info", style: "margin: 5px; font-weight: bold;" %>
 				<%= link_to 'Review this game!', "#{game_path(game)}#new_player_review", class: "btn btn-primary", style: "margin: 5px; font-weight: bold;" %>
 			</div>
 		</div>

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -17,7 +17,7 @@
 					<% end %>
 			  <%= render 'games/game_info', game: game, hide_title: true %>
 			  <%= tracked_link_to "Play on this game's site!", game.website_url, class: "btn btn-success", style: "margin: 5px; font-weight: bold;", target: "_blank" %>
-				<%= link_to "Read #{game.player_reviews.approved.count > 0 ? pluralize(game.player_reviews.approved.count, 'Review') : "Reviews"}", "#{game_path(game)}#scorecards", class: "btn btn-info", style: "margin: 5px; font-weight: bold;" %>
+				<%= link_to "Read #{game.approved_reviews_count > 0 ? pluralize(game.approved_reviews_count, 'Review') : "Reviews"}", "#{game_path(game)}#scorecards", class: "btn btn-info", style: "margin: 5px; font-weight: bold;" %>
 				<%= link_to 'Review this game!', "#{game_path(game)}#new_player_review", class: "btn btn-primary", style: "margin: 5px; font-weight: bold;" %>
 			</div>
 		</div>

--- a/db/migrate/20150407234336_add_approved_reviews_count_to_games.rb
+++ b/db/migrate/20150407234336_add_approved_reviews_count_to_games.rb
@@ -1,0 +1,5 @@
+class AddApprovedReviewsCountToGames < ActiveRecord::Migration
+  def change
+    add_column :games, :approved_reviews_count, :integer, default: 0
+  end
+end


### PR DESCRIPTION
Improve "Find Games" index
- sorting options:
  - most recently reviewed / updated (default)
  - most reviews (count)
  - most recently added
  - title alphabetically (current default / only option)
- Show # of reviews for each game right on its index entry